### PR TITLE
On personally administered laptops, make the first user primary user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ installdirs :
 	mkdir -p $(DESTDIR)$(datarootdir)/applications
 	mkdir -p $(DESTDIR)$(datarootdir)/puavo-ltsp/init-puavo.d
 	mkdir -p $(DESTDIR)$(libdir)/puavo-local-config-ui
+	mkdir -p $(DESTDIR)$(libdir)/puavo-local-config/pam
 	mkdir -p $(DESTDIR)$(sysconfdir)/xdg/autostart
 
 .PHONY : install
@@ -42,6 +43,9 @@ install : installdirs
 		plc-ui/package.json \
 		plc-ui/style.css    \
 		plc-ui/theme.css
+	
+	$(INSTALL_PROGRAM) -t $(DESTDIR)$(libdir)/puavo-local-config/pam \
+		pam/login-setup
 	
 	$(INSTALL_DATA) -t $(DESTDIR)$(sysconfdir)/xdg/autostart \
 		puavo-local-config-ui-autostart.desktop

--- a/init-puavo.d/97-puavo-local-config
+++ b/init-puavo.d/97-puavo-local-config
@@ -1,9 +1,13 @@
 puavo_personally_administered=$(jq -r .personally_administered \
 				      /etc/puavo/device.json)
 
-if [ "$puavo_personally_administered" = "true" ]; then
-  /usr/sbin/puavo-local-config --admins               \
-                               --disable-remoteadmins \
-                               --grub-default         \
-                               --local-users
+puavo_hosttype=$(cat /etc/puavo/hosttype)
+
+if [ "$puavo_hosttype" = "laptop" \
+     -a "$puavo_personally_administered" = "true" ]; then
+  /usr/sbin/puavo-local-config --admins                \
+                               --disable-remoteadmins  \
+                               --grub-default          \
+                               --local-users           \
+                               --networkmanager-policy
 fi

--- a/pam/login-setup
+++ b/pam/login-setup
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+if [ -s /var/lib/extrausers/passwd -o -s /var/lib/extrausers/group ]; then
+  # not the first login on this host
+  # (note that this test means that this should be run before populate-users
+  # in puavo-ltsp-client, otherwise this just will not work)
+  exit 0
+fi
+
+personally_administered=$(jq -r .personally_administered \
+                                /etc/puavo/device.json)
+
+if [ "$personally_administered" != 'true' ]; then
+  # host is not personally administered
+  exit 0
+fi
+
+# first login on a personally administered host, setup this user as the
+# primary user
+
+echo "$PAM_USER" > /state/etc/puavo/local/firstlogin_primary_user
+
+/usr/sbin/puavo-local-config --admins --networkmanager-policy

--- a/pam/login-setup
+++ b/pam/login-setup
@@ -1,43 +1,67 @@
 #!/usr/bin/ruby1.9.1
 
 require 'json'
+require 'syslog'
 
-device_json_path = '/state/etc/puavo/device.json'
+Syslog.open('puavo-local-config/pam/login-setup', Syslog::LOG_CONS)
 
-device = JSON.parse( IO.read(device_json_path) )
+begin
+  device_json_path = '/state/etc/puavo/device.json'
 
-if device['personally_administered'] != true then
-  # this host is not personally administered, do nothing
-  exit 0
-end
+  device = JSON.parse( IO.read(device_json_path) )
 
-if (device['primary_user'] || '').empty? then
-  # This test should be run before populate-users in puavo-ltsp-client,
-  # otherwise this just will not work.
-  if test(?s, '/var/lib/extrausers/passwd') \
-       || test(?s, '/var/lib/extrausers/group') then
-    # /var/lib/extrausers/{passwd,group} exist and have non-zero size,
-    # so we deduce that this is not the first login on this host and we do
-    # nothing.  (We could add the user as primary_user, but I think it is
-    # better to prevent accidents by having this check).
-    exit 0
+  if device['personally_administered'] != true then
+    Syslog.info('not a personally administered host, doing nothing')
+    exit(0)
   end
 
-  device['primary_user'] = ENV['PAM_USER']
-  File.open('/state/etc/puavo/primary_user_override', 'w') do |f|
-    f.puts(device['primary_user'])
+  if (device['primary_user'] || '').empty? then
+    # This test should be run before populate-users in puavo-ltsp-client,
+    # otherwise this just will not work.
+    if test(?s, '/var/lib/extrausers/passwd') \
+	 || test(?s, '/var/lib/extrausers/group') then
+      # /var/lib/extrausers/{passwd,group} exist and have non-zero size,
+      # so we deduce that this is not the first login on this host and we do
+      # nothing.  (We could add the user as primary_user, but I think it is
+      # better to prevent accidents by having this check).
+      Syslog.warning('primary user is not set, but this is not the first' \
+                       + ' login on this host')
+      exit(0)
+    end
+
+    Syslog.notice('making %s the primary user by using the override mechanism',
+                  ENV['PAM_USER'])
+
+    device['primary_user'] = ENV['PAM_USER']
+
+    primary_user_override_path = '/state/etc/puavo/primary_user_override'
+    File.open(primary_user_override_path, 'w') do |f|
+      f.puts(device['primary_user'])
+      Syslog.info('wrote %s', primary_user_override_path)
+    end
+    tmpfile = "#{ device_json_path }.login-setup.tmp"
+    File.open(tmpfile, 'w') { |f| f.write(device.to_json) }
+    File.rename(tmpfile, device_json_path)
+
+    Syslog.info('wrote %s', device_json_path)
   end
-  tmpfile = "#{ device_json_path }.login-setup.tmp"
-  File.open(tmpfile, 'w') { |f| f.write(device.to_json) }
-  File.rename(tmpfile, device_json_path)
+
+  Syslog.info('running puavo-local-config --admins --networkmanager-policy')
+
+  # This adds the primary user into the puavoadmins-group... it must not be
+  # done unless primary_user is reliably set in device.json, because adding a
+  # login to puavoadmins-group has the side effect of starting up
+  # puavo-local-config-ui in desktop login, which has a side effect creating
+  # /state/etc/puavo/local/config.json, which has a side effect of restricting
+  # logins to primary user and those listed in that file.  If primary_user is
+  # not set in device.json, no one can log in.
+  system('/usr/sbin/puavo-local-config',
+         '--admins',
+         '--networkmanager-policy') \
+    or raise "Problem running /usr/sbin/puavo-local-config: #{ $?.exitstatus }"
+rescue StandardError => e
+  Syslog.err('%s', e.message)
+  raise e
 end
 
-# This adds the primary user into the puavoadmins-group... it must not be done
-# unless primary_user is reliably set in device.json, because adding a login
-# to puavoadmins-group has the side effect of starting up puavo-local-config-ui
-# in desktop login, which has a side effect creating
-# /state/etc/puavo/local/config.json, which has a side effect of restricting
-# logins to primary user and those listed in that file.  If primary_user is
-# not set in device.json, no one can log in.
-system('/usr/sbin/puavo-local-config', '--admins', '--networkmanager-policy') \
-  or raise "Problem running /usr/sbin/puavo-local-config: #{ $?.exitstatus }"
+exit(0)

--- a/pam/login-setup
+++ b/pam/login-setup
@@ -1,25 +1,43 @@
-#!/bin/sh
+#!/usr/bin/ruby1.9.1
 
-set -eu
+require 'json'
 
-if [ -s /var/lib/extrausers/passwd -o -s /var/lib/extrausers/group ]; then
-  # not the first login on this host
-  # (note that this test means that this should be run before populate-users
-  # in puavo-ltsp-client, otherwise this just will not work)
+device_json_path = '/state/etc/puavo/device.json'
+
+device = JSON.parse( IO.read(device_json_path) )
+
+if device['personally_administered'] != true then
+  # this host is not personally administered, do nothing
   exit 0
-fi
+end
 
-personally_administered=$(jq -r .personally_administered \
-                                /etc/puavo/device.json)
+if (device['primary_user'] || '').empty? then
+  # This test should be run before populate-users in puavo-ltsp-client,
+  # otherwise this just will not work.
+  if test(?s, '/var/lib/extrausers/passwd') \
+       || test(?s, '/var/lib/extrausers/group') then
+    # /var/lib/extrausers/{passwd,group} exist and have non-zero size,
+    # so we deduce that this is not the first login on this host and we do
+    # nothing.  (We could add the user as primary_user, but I think it is
+    # better to prevent accidents by having this check).
+    exit 0
+  end
 
-if [ "$personally_administered" != 'true' ]; then
-  # host is not personally administered
-  exit 0
-fi
+  device['primary_user'] = ENV['PAM_USER']
+  File.open('/state/etc/puavo/local/primary_user_override', 'w') do |f|
+    f.puts(device['primary_user'])
+  end
+  tmpfile = "#{ device_json_path }.login-setup.tmp"
+  File.open(tmpfile, 'w') { |f| f.write(device.to_json) }
+  File.rename(tmpfile, device_json_path)
+end
 
-# first login on a personally administered host, setup this user as the
-# primary user
-
-echo "$PAM_USER" > /state/etc/puavo/local/firstlogin_primary_user
-
-/usr/sbin/puavo-local-config --admins --networkmanager-policy
+# This adds the primary user into the puavoadmins-group... it must not be done
+# unless primary_user is reliably set in device.json, because adding a login
+# to puavoadmins-group has the side effect of starting up puavo-local-config-ui
+# in desktop login, which has a side effect creating
+# /state/etc/puavo/local/config.json, which has a side effect of restricting
+# logins to primary user and those listed in that file.  If primary_user is
+# not set in device.json, no one can log in.
+system('/usr/sbin/puavo-local-config', '--admins', '--networkmanager-policy') \
+  or raise "Problem running /usr/sbin/puavo-local-config: #{ $?.exitstatus }"

--- a/pam/login-setup
+++ b/pam/login-setup
@@ -24,7 +24,7 @@ if (device['primary_user'] || '').empty? then
   end
 
   device['primary_user'] = ENV['PAM_USER']
-  File.open('/state/etc/puavo/local/primary_user_override', 'w') do |f|
+  File.open('/state/etc/puavo/primary_user_override', 'w') do |f|
     f.puts(device['primary_user'])
   end
   tmpfile = "#{ device_json_path }.login-setup.tmp"

--- a/puavo-local-config
+++ b/puavo-local-config
@@ -146,7 +146,7 @@ def configure_admins()
 
   search_and_replace_line('/etc/gshadow',
                          /^puavolocaladmins:/,
-                         'puavolocaladmins:!::')
+                         "puavolocaladmins:!::#{ admin }")
 
   File.open('/etc/sudoers.d/puavolocaladmins.pcltmp', 'w') do |f|
     if superlaptop_mode? then

--- a/puavo-local-config
+++ b/puavo-local-config
@@ -22,16 +22,17 @@ def print_help()
   puts <<-EOF
 puavo-local-config [OPTIONS]
 
--c, --config-path      set configuration file path
--h, --help             show help
+-c, --config-path           set configuration file path
+-h, --help                  show help
 
-    --admins           configure admins
-    --grub-default     configure grub default
-    --local-users      configure local users
-    --setup-pkgs       configure installed (optional) packages
+    --admins                configure admins
+    --grub-default          configure grub default
+    --local-users           configure local users
+    --networkmanager-policy apply special networkmanager permissions
+    --setup-pkgs            configure installed (optional) packages
 
-    --install-pkgs     ["all" | a list of software separated with comma]
-    --uninstall-pkgs   ["all" | a list of software separated with comma]
+    --install-pkgs          ["all" | a list of software separated with comma]
+    --uninstall-pkgs        ["all" | a list of software separated with comma]
   EOF
 end
 
@@ -223,6 +224,27 @@ def configure_grub_default()
     or raise 'Problem in updating grub environment'
 end
 
+def configure_nm_policy()
+  device = read_device()
+  admin  = device['primary_user']
+
+  confpath = '/etc/polkit-1/localauthority/50-local.d/10.org.freedesktop.networkmanager.allow_modify_by_primary_user.pkla'
+
+  if admin then
+    conf = <<"EOF"
+[Primary user permissions]
+Identity=unix-user:#{ admin }
+Action=org.freedesktop.NetworkManager.settings.modify.system
+ResultAny=no
+ResultInactive=no
+ResultActive=yes
+EOF
+    File.open(confpath, 'w') { |f| f.print conf }
+  else
+    FileUtils.rm_f(confpath)
+  end
+end
+
 def install_pkgs(pkg_list)
   %w(download install).each do |action|
     restricted_package_tool(action, *pkg_list) \
@@ -237,8 +259,9 @@ def parse_pkg_list(pkg_list)
     : pkg_list.split(',')
 end
 
+$device = nil
 def read_device()
-  JSON.parse( IO.read('/state/etc/puavo/device.json') )
+  $device ||= JSON.parse( IO.read('/state/etc/puavo/device.json') )
 end
 
 def reset_allow_remoteadmins(conf, config_path)
@@ -284,16 +307,17 @@ uninstall_pkg_list   = []
 
 begin
   opts = GetoptLong.new(
-    [ '--config-path',   '-c',  GetoptLong::REQUIRED_ARGUMENT, ],
-    [ '--help',          '-h',  GetoptLong::NO_ARGUMENT,       ],
+    [ '--config-path',   '-c',   GetoptLong::REQUIRED_ARGUMENT, ],
+    [ '--help',          '-h',   GetoptLong::NO_ARGUMENT,       ],
 
-    [ '--admins',               GetoptLong::NO_ARGUMENT,       ],
-    [ '--disable-remoteadmins', GetoptLong::NO_ARGUMENT,       ],
-    [ '--grub-default',         GetoptLong::NO_ARGUMENT,       ],
-    [ '--local-users',          GetoptLong::NO_ARGUMENT,       ],
-    [ '--install-pkgs',         GetoptLong::REQUIRED_ARGUMENT, ],
-    [ '--setup-pkgs',           GetoptLong::NO_ARGUMENT,       ],
-    [ '--uninstall-pkgs',       GetoptLong::REQUIRED_ARGUMENT, ],
+    [ '--admins',                GetoptLong::NO_ARGUMENT,       ],
+    [ '--disable-remoteadmins',  GetoptLong::NO_ARGUMENT,       ],
+    [ '--grub-default',          GetoptLong::NO_ARGUMENT,       ],
+    [ '--local-users',           GetoptLong::NO_ARGUMENT,       ],
+    [ '--install-pkgs',          GetoptLong::REQUIRED_ARGUMENT, ],
+    [ '--networkmanager-policy', GetoptLong::NO_ARGUMENT,       ],
+    [ '--setup-pkgs',            GetoptLong::NO_ARGUMENT,       ],
+    [ '--uninstall-pkgs',        GetoptLong::REQUIRED_ARGUMENT, ],
   )
 
   opts.each do |opt, arg|
@@ -310,6 +334,8 @@ begin
       when '--install-pkgs'
 	apply_configs.push(opt)
 	install_pkg_list = parse_pkg_list(arg)
+      when '--networkmanager-policy'
+	apply_configs.push(opt)
       when '--setup-pkgs'
 	apply_configs.push(opt)
       when '--uninstall-pkgs'
@@ -345,12 +371,13 @@ if disable_remoteadmins then
 end
 
 dispatch_table = {
-  '--admins'         => lambda { configure_admins()                 },
-  '--grub-default'   => lambda { configure_grub_default()           },
-  '--local-users'    => lambda { configure_local_users(conf)        },
-  '--install-pkgs'   => lambda { install_pkgs(install_pkg_list)     },
-  '--setup-pkgs'     => lambda { setup_pkgs()                       },
-  '--uninstall-pkgs' => lambda { uninstall_pkgs(uninstall_pkg_list) },
+  '--admins'                => lambda { configure_admins()                 },
+  '--grub-default'          => lambda { configure_grub_default()           },
+  '--local-users'           => lambda { configure_local_users(conf)        },
+  '--install-pkgs'          => lambda { install_pkgs(install_pkg_list)     },
+  '--networkmanager-policy' => lambda { configure_nm_policy()              },
+  '--setup-pkgs'            => lambda { setup_pkgs()                       },
+  '--uninstall-pkgs'        => lambda { uninstall_pkgs(uninstall_pkg_list) },
 }
 
 exit_code = 0

--- a/puavo-local-config
+++ b/puavo-local-config
@@ -15,6 +15,7 @@ require 'etc'
 require 'fileutils'
 require 'getoptlong'
 require 'json'
+require 'syslog'
 
 Ltspadmins_group_id = 3000
 
@@ -36,6 +37,14 @@ puavo-local-config [OPTIONS]
   EOF
 end
 
+def syslog(channel, priority, *args)
+  Syslog.log(priority, *args)
+  channel.printf(*args)
+end
+
+def log(*args)   ; syslog(STDOUT, *args); end
+def logerr(*args); syslog(STDERR, *args); end
+
 def conf_version_1_ok?(conf)
   is_boolean = lambda { |v| v.kind_of?(TrueClass) || v.kind_of?(FalseClass) }
 
@@ -56,7 +65,8 @@ end
 
 def ensure_conf_sanity(conf, config_path)
   move_conf = lambda {
-                warn 'Moving configuration file, because it is messed up'
+                logerr(Syslog::LOG_CRIT,
+                      "Moving configuration file, because it is messed up\n")
                 FileUtils.mv(config_path,
                              "#{ config_path }.backup-#{ Time.now().to_i }")
               }
@@ -94,7 +104,7 @@ def get_primary_user()
       raise 'Primary user is not set or is in invalid format'
     end
   rescue StandardError => e
-    warn "Could not find primary user: #{ e.message }"
+    logerr(Syslog::LOG_WARNING, "Could not find primary user: %s\n", e.message)
     return nil
   end
 
@@ -135,6 +145,8 @@ def search_and_replace_line(file, re, new_line)
 end
 
 def configure_admins()
+  log(Syslog::LOG_INFO, "configuring admins\n")
+
   admin = get_primary_user() || ''
 
   kernel_cmdline = IO.read('/proc/cmdline')
@@ -162,6 +174,8 @@ end
 def configure_local_users(conf)
   return if conf.nil?
 
+  log(Syslog::LOG_INFO, "configuring local users\n")
+
   primary_user = get_primary_user()
 
   uid_min, uid_max = 3001, 3999
@@ -171,18 +185,20 @@ def configure_local_users(conf)
 
   conf['local_users'].each do |login, user|
     if user['uid'] < uid_min then
-      warn "uid is below uid_min for '#{ login }'"
+      logerr(Syslog::LOG_WARNING, "uid is below uid_min for %s\n", login)
       problems = true
       next
     end
     if user['uid'] > uid_max
-      warn "uid is over uid_max for '#{ login }'"
+      logerr(Syslog::LOG_WARNING, "uid is over uid_max for %s\n", login)
       problems = true
       next
     end
 
     if primary_user == login then
-      warn "disabling login that is reserved for primary user: '#{ login }'"
+      logerr(Syslog::LOG_WARNING,
+             "disabling login that is reserved for primary user: %s\n",
+             login)
       user['enabled'] = false
     end
 
@@ -210,10 +226,12 @@ def configure_local_users(conf)
 end
 
 def configure_grub_default()
+  log(Syslog::LOG_INFO, "configuring grub default\n")
+
   kernel_cmdline = IO.read('/proc/cmdline')
 
   if kernel_cmdline.match(%r{root=/dev/nbd}) then
-    # booted from nbd, nothing to do
+    log(Syslog::LOG_INFO, "booted from nbd, nothing to do\n")
     return
   end
 
@@ -249,6 +267,8 @@ def configure_grub_default()
 end
 
 def configure_nm_policy()
+  log(Syslog::LOG_INFO, "configuring network manager policy\n")
+
   admin = get_primary_user()
 
   confpath = '/etc/polkit-1/localauthority/50-local.d/10.org.freedesktop.networkmanager.allow_modify_by_primary_user.pkla'
@@ -285,6 +305,8 @@ end
 def reset_allow_remoteadmins(conf, config_path)
   return conf if (conf.nil? || conf['allow_remoteadmins'] == false)
 
+  log(Syslog::LOG_NOTICE, "remoteadmins were allowed in, disallowing\n")
+
   # if allow_remoteadmins were set to true, set it false
 
   conf['allow_remoteadmins'] = false
@@ -315,6 +337,8 @@ def uninstall_pkgs(pkg_list)
   restricted_package_tool('uninstall', *pkg_list) \
     or raise "Problem in uninstalling: #{ pkg_list.join(', ') }"
 end
+
+Syslog.open(File.basename($0), Syslog::LOG_CONS)
 
 config_path = '/state/etc/puavo/local/config.json'
 
@@ -378,7 +402,10 @@ begin
 rescue Errno::ENOENT
   conf = nil
 rescue Exception => e
-  warn "Could not read and interpret #{ config_path }: #{ e.message }"
+  logerr(Syslog::LOG_ERR,
+         "Could not read and interpret %s: %s\n",
+         config_path,
+         e.message)
   conf = nil
 end
 
@@ -404,9 +431,13 @@ apply_configs.each do |part|
   begin
     dispatch_table[part].call()
   rescue Exception => e
-    warn "Could not handle #{ part }: #{ e.message } / #{ e.backtrace }"
+    logerr(Syslog::LOG_ERR,
+           "%s\n",
+           "Could not handle #{ part }: #{ e.message } / #{ e.backtrace }")
     exit_code = 1
   end
 end
+
+Syslog.close()
 
 exit(exit_code)

--- a/puavo-local-config
+++ b/puavo-local-config
@@ -150,6 +150,10 @@ def configure_admins()
                          /^puavolocaladmins:/,
                          new_line)
 
+  search_and_replace_line('/etc/gshadow',
+                         /^puavolocaladmins:/,
+                         'puavolocaladmins:!::')
+
   File.open('/etc/sudoers.d/puavolocaladmins.pcltmp', 'w') do |f|
     if superlaptop_mode? then
       f.write("%puavolocaladmins ALL=(ALL) ALL\n")

--- a/puavo-local-config
+++ b/puavo-local-config
@@ -85,19 +85,13 @@ def get_primary_user()
   return $primary_user if $primary_user
 
   begin
-    primary_user \
-      = IO.read('/state/etc/puavo/local/firstlogin_primary_user').chomp \
-          rescue nil
-
-    if !primary_user then
-      device = JSON.parse( IO.read('/state/etc/puavo/device.json') )
-      primary_user = device.kind_of?(Hash) && device['primary_user']
-    end
+    device = JSON.parse( IO.read('/state/etc/puavo/device.json') )
+    primary_user = device.kind_of?(Hash) && device['primary_user']
 
     if primary_user && primary_user.match(/^[A-Za-z0-9\.\-]+$/) then
       $primary_user = primary_user
     else
-      raise 'no suitable source found'
+      raise 'Primary user is not set or is in invalid format'
     end
   rescue StandardError => e
     warn "Could not find primary user: #{ e.message }"

--- a/puavo-local-config
+++ b/puavo-local-config
@@ -80,6 +80,33 @@ def ensure_conf_sanity(conf, config_path)
   conf
 end
 
+$primary_user = nil
+def get_primary_user()
+  return $primary_user if $primary_user
+
+  begin
+    primary_user \
+      = IO.read('/state/etc/puavo/local/firstlogin_primary_user').chomp \
+          rescue nil
+
+    if !primary_user then
+      device = JSON.parse( IO.read('/state/etc/puavo/device.json') )
+      primary_user = device.kind_of?(Hash) && device['primary_user']
+    end
+
+    if primary_user && primary_user.match(/^[A-Za-z0-9\.\-]+$/) then
+      $primary_user = primary_user
+    else
+      raise 'no suitable source found'
+    end
+  rescue StandardError => e
+    warn "Could not find primary user: #{ e.message }"
+    return nil
+  end
+
+  $primary_user
+end
+
 def search_and_replace_line(file, re, new_line)
   File.open(file, 'r') do |inputf|
     output_lines = []
@@ -114,8 +141,7 @@ def search_and_replace_line(file, re, new_line)
 end
 
 def configure_admins()
-  device = read_device()
-  admin  = device['primary_user'] || ''
+  admin = get_primary_user() || ''
 
   kernel_cmdline = IO.read('/proc/cmdline')
 
@@ -138,7 +164,7 @@ end
 def configure_local_users(conf)
   return if conf.nil?
 
-  device = read_device()
+  primary_user = get_primary_user()
 
   uid_min, uid_max = 3001, 3999
   group_id = Etc.getgrnam('users').gid
@@ -157,7 +183,7 @@ def configure_local_users(conf)
       next
     end
 
-    if device['primary_user'] == login then
+    if primary_user == login then
       warn "disabling login that is reserved for primary user: '#{ login }'"
       user['enabled'] = false
     end
@@ -225,13 +251,12 @@ def configure_grub_default()
 end
 
 def configure_nm_policy()
-  device = read_device()
-  admin  = device['primary_user']
+  admin = get_primary_user()
 
   confpath = '/etc/polkit-1/localauthority/50-local.d/10.org.freedesktop.networkmanager.allow_modify_by_primary_user.pkla'
 
   if admin then
-    conf = <<"EOF"
+    conf = <<EOF
 [Primary user permissions]
 Identity=unix-user:#{ admin }
 Action=org.freedesktop.NetworkManager.settings.modify.system
@@ -257,11 +282,6 @@ def parse_pkg_list(pkg_list)
     ? Dir.glob('/usr/share/puavo-ltsp-client/restricted-packages/*') \
          .map { |s| File.basename(s) } \
     : pkg_list.split(',')
-end
-
-$device = nil
-def read_device()
-  $device ||= JSON.parse( IO.read('/state/etc/puavo/device.json') )
 end
 
 def reset_allow_remoteadmins(conf, config_path)


### PR DESCRIPTION
On personally administered laptops, where nobody has logged in yet, make the first user logging in the primary user.  Try to send this information to Puavo as well.

The changes in puavo-ltsp repository (primaryusersetup-branch) are needed as well.
